### PR TITLE
Generalize read_griddata_fits

### DIFF
--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -591,7 +591,9 @@ meta = {'type': 'SN Ia',
         'subclass': '`~sncosmo.MLCS2k2Source`',
         'reference': ('Jha07',
                       'Jha, Riess and Kirshner 2007 '
-                      '<http://adsabs.harvard.edu/abs/2007ApJ...659..122J>')}
+                      '<http://adsabs.harvard.edu/abs/2007ApJ...659..122J>'),
+        'note': 'In MLCS2k2 language, this version corresponds to '
+        '"MLCS2k2 v0.07 rv19-early-smix vectors"'}
 registry.register_loader(Source, 'mlcs2k2', load_mlcs2k2,
                          args=['models/mlcs2k2/mlcs2k2.modelflux.fits'],
                          version='1.0', meta=meta)

--- a/sncosmo/io.py
+++ b/sncosmo/io.py
@@ -185,7 +185,7 @@ def read_griddata_fits(name_or_obj, ext=0):
     for i in range(y.ndim):
         j = y.ndim - i  # The i-th axis (in Python) corresponds to FITS AXISj
         coords = np.zeros((y.shape[i], y.ndim), dtype=np.float32)
-        coords[:, j-1] = np.arange(nx)
+        coords[:, j-1] = np.arange(y.shape[i])
         x = w.wcs_pix2world(coords, 0)[:, j-1]
         xs.append(x)
 

--- a/sncosmo/io.py
+++ b/sncosmo/io.py
@@ -104,8 +104,8 @@ def read_griddata_ascii(name_or_obj):
 
 
 def read_griddata_fits(name_or_obj, ext=0):
-    """Read a 2-d grid of data from a FITS file, where the grid coordinates
-    are encoded in the FITS-WCS header keywords.
+    """Read a multi-dimensional grid of data from a FITS file, where the
+    grid coordinates are encoded in the FITS-WCS header keywords.
 
     Parameters
     ----------

--- a/sncosmo/io.py
+++ b/sncosmo/io.py
@@ -19,8 +19,7 @@ from astropy.extern import six
 from .photdata import dict_to_array
 
 __all__ = ['read_lc', 'write_lc', 'load_example_data', 'read_griddata_ascii',
-           'read_griddata_fits', 'write_griddata_ascii', 'write_griddata_fits',
-           'read_3dgriddata_fits']
+           'read_griddata_fits', 'write_griddata_ascii', 'write_griddata_fits']
 
 
 def _stripcomment(line, char='#'):
@@ -104,55 +103,6 @@ def read_griddata_ascii(name_or_obj):
     return np.array(x0), np.array(x1), np.array(y)
 
 
-def read_3dgriddata_fits(name_or_obj, ext=0):
-    """Read a 3-d grid of data from a FITS file, where the grid coordinates
-    are encoded in the FITS-WCS header keywords.
-
-    Parameters
-    ----------
-    name_or_obj : str or file-like object
-
-    Returns
-    -------
-    x0 : numpy.ndarray
-        1-d array.
-    x1 : numpy.ndarray
-        1-d array.
-    x2 : numpy.ndarray
-        1-d array.
-    y : numpy.ndarray
-        3-d array of shape (len(x0), len(x1), len(x2)).
-    """
-
-    hdulist = fits.open(name_or_obj)
-    w = wcs.WCS(hdulist[ext].header)
-    y = hdulist[ext].data
-    nx0, nx1, nx2 = y.shape
-
-    # get x0 values
-    coords = np.empty((nx2, 3), dtype=np.float32)
-    coords[:, 1:3] = 0.
-    coords[:, 0] = np.arange(nx2)  # x2 = FITS AXIS1 ("z" coordinates)
-    x2 = w.wcs_pix2world(coords, 0)[:, 0]
-
-    # get x1 values
-    coords = np.empty((nx1, 3), dtype=np.float32)
-    coords[:, 0] = 0.
-    coords[:, 1] = np.arange(nx1)  # x1 = FITS AXIS2 ("y" coordinates)
-    coords[:, 2] = 0.
-    x1 = w.wcs_pix2world(coords, 0)[:, 1]
-
-    # get x2 values
-    coords = np.empty((nx0, 3), dtype=np.float32)
-    coords[:, 2] = np.arange(nx0)  # x0 = FITS AXIS3 ("x" coordinates)
-    coords[:, 0:2] = 0.
-    x0 = w.wcs_pix2world(coords, 0)[:, 2]
-
-    hdulist.close()
-
-    return x0, x1, x2, y
-
-
 def read_griddata_fits(name_or_obj, ext=0):
     """Read a 2-d grid of data from a FITS file, where the grid coordinates
     are encoded in the FITS-WCS header keywords.
@@ -165,11 +115,11 @@ def read_griddata_fits(name_or_obj, ext=0):
     -------
     x0, x1, ... : `~numpy.ndarray`s
         1-d arrays giving coordinates of grid. The number of these arrays will
-        depend on the dimension of the data array. For example, if the data have
-        two dimensions, a total of three arrays will be returned: ``x0, x1, y``,
-        with ``x0`` giving the coordinates of the first axis of ``y``. If the
-        data have three dimensions, a total of four arrays will be returned:
-        ``x0, x1, x2, y``, and so on with higher dimensions.
+        depend on the dimension of the data array. For example, if the data
+        have two dimensions, a total of three arrays will be returned:
+        ``x0, x1, y``, with ``x0`` giving the coordinates of the first axis
+        of ``y``. If the data have three dimensions, a total of four arrays
+        will be returned: ``x0, x1, x2, y``, and so on with higher dimensions.
     y : `~numpy.ndarray`
         n-d array of shape ``(len(x0), len(x1), ...)``. For three dimensions
         for example, the value at ``y[i, j, k]`` corresponds to coordinates

--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -1000,6 +1000,8 @@ class MLCS2k2Source(Source):
     where _A_ is the amplitude and _Delta_ is the MLCS2k2 light curve shape
     parameter.
 
+    .. note:: Requires scipy version 0.14 or higher.
+
     Parameters
     ----------
     fluxfile : str or obj


### PR DESCRIPTION
This merges the functionality of `read_griddata_fits` and `read_3dgridata_fits` into a single function.

It also late-imports `RegularGridInterpolator` so that users with scipy version < 0.14 will still be able to use sncosmo, and will only get an error when trying to initialize an `MLCS2k2Source`.

It also updates the docstring for `MLCS2k2Source`, and adds a note about the meaning of v1.0 of the model in "mlcs2k2 langauge".
